### PR TITLE
Adding a new space_char argument for Trainer.

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "tokenizers-python"
-version = "0.9.0-dev0"
+version = "0.9.0-dev1"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
+++ b/bindings/python/py_src/tokenizers/implementations/sentencepiece_unigram.py
@@ -38,6 +38,7 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
             "replacement": replacement,
             "add_prefix_space": add_prefix_space,
         }
+        self.replacement = replacement
 
         super().__init__(tokenizer, parameters)
 
@@ -47,11 +48,16 @@ class SentencePieceUnigramTokenizer(BaseTokenizer):
         vocab_size: int = 8000,
         show_progress: bool = True,
         special_tokens: List[Union[str, AddedToken]] = [],
+        space_char: Union[None, str] = None,
     ):
         """ Train the model using the given files """
+        space_char = space_char if space_char is not None else self.replacement
 
         trainer = trainers.UnigramTrainer(
-            vocab_size=vocab_size, special_tokens=special_tokens, show_progress=show_progress,
+            vocab_size=vocab_size,
+            special_tokens=special_tokens,
+            show_progress=show_progress,
+            space_char=space_char,
         )
 
         if isinstance(files, str):

--- a/bindings/python/py_src/tokenizers/trainers/__init__.pyi
+++ b/bindings/python/py_src/tokenizers/trainers/__init__.pyi
@@ -123,6 +123,7 @@ class UnigramTrainer(Trainer):
         vocab_size: int = 8000,
         show_progress: bool = True,
         special_tokens: List[Union[str, AddedToken]] = [],
+        space_char: str = "▁",
     ) -> Trainer:
         """ Instantiate a new UnigramTrainer with the given options:
 
@@ -135,6 +136,9 @@ class UnigramTrainer(Trainer):
 
             special_tokens: List[Union[str, AddedToken]]:
                 A list of special tokens the model should know of.
+
+            space_char: str:
+                Which character is used as a space (useful when using replacement character)
 
         Returns:
             Trainer

--- a/bindings/python/scripts/spm_parity_check.py
+++ b/bindings/python/scripts/spm_parity_check.py
@@ -2,6 +2,7 @@ import tokenizers
 from argparse import ArgumentParser
 import sentencepiece as spm
 import json
+import os
 
 
 def main():
@@ -35,6 +36,9 @@ def main():
         check_train(args)
     else:
         check_encode(args)
+
+    os.remove(f"{args.model_prefix}.model")
+    os.remove(f"{args.model_prefix}.vocab")
 
 
 def check_train(args):
@@ -77,6 +81,7 @@ def check_train(args):
     assert (
         tokenizer_tokens < spm_tokens
     ), "Our trainer should be at least more efficient than the SPM one"
+    print("Ok we are at least better than spm_train")
 
 
 def check_encode(args):
@@ -93,21 +98,25 @@ def check_encode(args):
     with open(vocab_filename, "w") as f:
         json.dump(data, f, indent=4)
 
-    tok = tokenizers.SentencePieceUnigramTokenizer(vocab_filename)
-    with open(args.input_file, "r") as f:
-        for i, line in enumerate(f):
-            line = line.strip()
-            ids = sp.EncodeAsIds(line)
+    try:
+        tok = tokenizers.SentencePieceUnigramTokenizer(vocab_filename)
+        with open(args.input_file, "r") as f:
+            for i, line in enumerate(f):
+                line = line.strip()
+                ids = sp.EncodeAsIds(line)
 
-            encoded = tok.encode(line)
+                encoded = tok.encode(line)
 
-            if ids != encoded.ids:
-                # Encoding can be the same with same result AAA -> A + AA vs AA + A
-                # We can check that we use at least exactly the same number of tokens.
-                assert len(ids) == len(encoded.ids)
-                continue
+                if ids != encoded.ids:
+                    # Encoding can be the same with same result AAA -> A + AA vs AA + A
+                    # We can check that we use at least exactly the same number of tokens.
+                    assert len(ids) == len(encoded.ids)
+                    continue
 
-            assert ids == encoded.ids, f"line {i}: {line} : {ids} != {encoded.ids}"
+                assert ids == encoded.ids, f"line {i}: {line} : {ids} != {encoded.ids}"
+    finally:
+        os.remove(vocab_filename)
+    print("Ok we have parity !")
 
 
 if __name__ == "__main__":

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="anthony@huggingface.co",
     url="https://github.com/huggingface/tokenizers",
     license="Apache License 2.0",
-    rust_extensions=[RustExtension("tokenizers.tokenizers", binding=Binding.PyO3)],
+    rust_extensions=[RustExtension("tokenizers.tokenizers", binding=Binding.PyO3, debug=False)],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/bindings/python/src/trainers.rs
+++ b/bindings/python/src/trainers.rs
@@ -193,6 +193,18 @@ impl PyUnigramTrainer {
                     "unk_token" => builder.unk_token(val.extract()?),
                     "max_piece_length" => builder.max_piece_length(val.extract()?),
                     "seed_size" => builder.seed_size(val.extract()?),
+                    "space_char" => {
+                        let space_string: String = val.extract()?;
+                        if space_string.chars().count() != 1 {
+                            return Err(exceptions::Exception::py_err(
+                                "space_char must be a single char",
+                            ));
+                        } else {
+                            builder.space_char(space_string.chars().next().ok_or_else(|| {
+                                exceptions::Exception::py_err("space_char must be a single char")
+                            })?)
+                        }
+                    }
                     "special_tokens" => builder.special_tokens(
                         val.cast_as::<PyList>()?
                             .into_iter()

--- a/tokenizers/src/models/unigram/trainer.rs
+++ b/tokenizers/src/models/unigram/trainer.rs
@@ -106,9 +106,9 @@ impl UnigramTrainer {
     }
 
     fn is_valid_sentencepiece(&self, char_string: &[char]) -> bool {
-        // TODO check more formally but should be ok.
         // Checks string length, space not in the substring, numbers, hiragana and more
         // https://github.com/google/sentencepiece/blob/26be9516cd81d5315ee31c48d2438018e0eab879/src/trainer_interface.cc#L203
+
         let n = char_string.len();
         if char_string.is_empty() || n > self.max_piece_length {
             return false;

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::reversed_empty_ranges)]
-
 use crate::pattern::Pattern;
 use crate::{Offsets, Result};
 use std::ops::{Bound, RangeBounds};
@@ -1038,7 +1036,6 @@ impl From<&str> for NormalizedString {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::reversed_empty_ranges)]
     use super::*;
     use regex::Regex;
     use unicode_categories::UnicodeCategories;


### PR DESCRIPTION
By default Trainer uses ' ' as `space_char`, that means
that in the default implementation `▁` is actually treated as a regular
char, which has a specific SCRIPT tag, which ruins the vocab.

We `need` to have a way to control `space_char` from the python side (in
case we don't use Metaspace). We can always use the standard
`replacement` as a default though.

The parity check actually currently fails on `big.txt` but the number of
tokens is in the same ballpark `153k vs 152k`. In order to do the check
with OK speed, we need to compile in `--release` mode which is not the
default. In the current commit I propose to simply disable `--debug`
builds has they are probably not useful to anyone.